### PR TITLE
enable CONNECT for https: endpoints (i.e. Docker apt repos)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV APT_CACHER_NG_VERSION=0.7.26 \
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y apt-cacher-ng=${APT_CACHER_NG_VERSION}* \
  && sed 's/# ForeGround: 0/ForeGround: 1/' -i /etc/apt-cacher-ng/acng.conf \
+ && sed 's/# PassThroughPattern:.*this would allow.*/PassThroughPattern: .* #/' -i /etc/apt-cacher-ng/acng.conf \
  && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /sbin/entrypoint.sh


### PR DESCRIPTION
- enable the apt-cacher-ng CONNECT passthrough by default.
- makes it a fully working proxy http and https
