### PR TITLE
Update Dockerfile to add ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV APT_CACHER_NG_VERSION=3.1 \
 
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-      apt-cacher-ng=${APT_CACHER_NG_VERSION}* \
+      apt-cacher-ng=${APT_CACHER_NG_VERSION}* ca-certificates \
  && sed 's/# ForeGround: 0/ForeGround: 1/' -i /etc/apt-cacher-ng/acng.conf \
  && sed 's/# PassThroughPattern:.*this would allow.*/PassThroughPattern: .* #/' -i /etc/apt-cacher-ng/acng.conf \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
If you add this package, you can keep HTTP between servers and apt-cacher-ng (and caching packages) and in same time, you give capabilities for apt-cacher-ng to download packages on HTTPS repository. 

for exemple:
* on all servers: 
deb http://download.docker.com/linux/debian stretch stable
* on apt-cacher-ng:
Remap-docker: download.docker.com ; https://download.docker.com