### PR TITLE
update to ubuntu disco with apt-cacher-ng 3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:bionic-20181204
+FROM ubuntu:disco
 
 LABEL maintainer="sameer@damagehead.com"
 
-ENV APT_CACHER_NG_VERSION=3.1 \
+ENV APT_CACHER_NG_VERSION=3.2 \
     APT_CACHER_NG_CACHE_DIR=/var/cache/apt-cacher-ng \
     APT_CACHER_NG_LOG_DIR=/var/log/apt-cacher-ng \
     APT_CACHER_NG_USER=apt-cacher-ng


### PR DESCRIPTION
In order to update to 3.2 you have to use a newer version of ubuntu. Seeing as there is no newer LTS I went for the latest ubuntu version.