### PR TITLE
tweak healthcheck as it was failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN chmod 755 /sbin/entrypoint.sh
 EXPOSE 3142/tcp
 
 HEALTHCHECK --interval=10s --timeout=2s --retries=3 \
-    CMD wget -q0 - http://localhost:3142/acng-report.html || exit 1
+    CMD wget --quiet --tries=1 --spider  http://localhost:3142/acng-report.html || exit 1
 
 ENTRYPOINT ["/sbin/entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN chmod 755 /sbin/entrypoint.sh
 EXPOSE 3142/tcp
 
 HEALTHCHECK --interval=10s --timeout=2s --retries=3 \
-    CMD wget --quiet --tries=1 --spider  http://localhost:3142/acng-report.html || exit 1
+    CMD wget -q -t1 -o /dev/null  http://localhost:3142/acng-report.html || exit 1
 
 ENTRYPOINT ["/sbin/entrypoint.sh"]
 


### PR DESCRIPTION
Hi, I noticed that my container was showing as unhealthy, due to the `0` in the `wget -q0` so I played with the options to get it to pass

`--tries=1` is because wget will retry either 20, or in some cases infinite, times if the check isn't successful
`--spider` makes wget not actually download the page, just check that it's there